### PR TITLE
Update clipping to use start/end times

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,25 @@ This repository contains a simple command line tool to create clips from an AWS 
 python live_clipping.py \
   --endpoint-id <origin_endpoint_id> \
   --start 2023-01-01T12:00:00 \
-  --duration 60 \
+  --end 2023-01-01T12:01:00 \
   --bucket my-bucket \
   --manifest-prefix clips/myclip \
   --role-arn arn:aws:iam::111122223333:role/MediaPackageHarvest
 ```
 
-This command creates a 60 second clip starting at the specified time. The resulting manifest and segments will be stored in the provided S3 bucket and prefix.
+This command creates a clip between the given start and end times. The resulting manifest and segments will be stored in the provided S3 bucket and prefix.
+
+## Web Interface
+
+A simple Flask application is included to create clips from a browser. Install
+Flask and run the server:
+
+```bash
+pip install flask
+python web_app.py
+```
+
+Then open `http://localhost:5000` in your browser. The page shows a video player
+and a form to submit the start and end times along with other parameters. After
+filling out the fields press "Create Clip" and the server will request a harvest
+job from MediaPackage.

--- a/live_clipping.py
+++ b/live_clipping.py
@@ -1,5 +1,5 @@
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime
 import boto3
 
 
@@ -10,8 +10,8 @@ def parse_args():
                         help='MediaPackage OriginEndpoint ID')
     parser.add_argument('--start', required=True,
                         help='Clip start time in ISO 8601 UTC format (YYYY-MM-DDTHH:MM:SS)')
-    parser.add_argument('--duration', type=int, required=True,
-                        help='Duration of the clip in seconds')
+    parser.add_argument('--end', required=True,
+                        help='Clip end time in ISO 8601 UTC format (YYYY-MM-DDTHH:MM:SS)')
     parser.add_argument('--bucket', required=True,
                         help='S3 bucket for the harvested clip')
     parser.add_argument('--manifest-prefix', required=True,
@@ -24,7 +24,7 @@ def parse_args():
 
 def create_clip(args):
     start_time = datetime.fromisoformat(args.start)
-    end_time = start_time + timedelta(seconds=args.duration)
+    end_time = datetime.fromisoformat(args.end)
     client = boto3.client('mediapackage', region_name=args.region)
     response = client.create_harvest_job(
         Id=f"clip-{int(datetime.utcnow().timestamp())}",

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Live Clipping</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        video { display: block; margin-bottom: 20px; }
+        label { display: block; margin: 5px 0; }
+    </style>
+</head>
+<body>
+<h1>AWS MediaLive Clipping</h1>
+
+<video id="video" width="640" controls autoplay>
+    <source src="{{ video_url }}" type="application/vnd.apple.mpegurl">
+    Your browser does not support the video tag.
+</video>
+
+<div>
+    <label>Start Time (UTC): <input type="text" id="start"></label>
+    <button onclick="setStartNow()">Set Start to Now</button>
+</div>
+<div>
+    <label>End Time (UTC): <input type="text" id="end"></label>
+    <button onclick="setEndNow()">Set End to Now</button>
+</div>
+<div>
+    <label>Endpoint ID: <input type="text" id="endpoint_id"></label>
+</div>
+<div>
+    <label>Bucket: <input type="text" id="bucket"></label>
+</div>
+<div>
+    <label>Manifest Prefix: <input type="text" id="manifest_prefix"></label>
+</div>
+<div>
+    <label>Role ARN: <input type="text" id="role_arn"></label>
+</div>
+<div>
+    <label>Region: <input type="text" id="region" value="us-east-1"></label>
+</div>
+
+<button onclick="createClip()">Create Clip</button>
+
+<pre id="result"></pre>
+
+<script>
+function setStartNow() {
+    const now = new Date().toISOString().slice(0, 19);
+    document.getElementById('start').value = now;
+}
+
+function setEndNow() {
+    const now = new Date().toISOString().slice(0, 19);
+    document.getElementById('end').value = now;
+}
+
+async function createClip() {
+    const payload = {
+        endpoint_id: document.getElementById('endpoint_id').value,
+        start: document.getElementById('start').value,
+        end: document.getElementById('end').value,
+        bucket: document.getElementById('bucket').value,
+        manifest_prefix: document.getElementById('manifest_prefix').value,
+        role_arn: document.getElementById('role_arn').value,
+        region: document.getElementById('region').value
+    };
+    const res = await fetch('/clip', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+}
+</script>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from flask import Flask, render_template, request, jsonify
+from live_clipping import create_clip
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    # Replace with your HLS manifest URL
+    video_url = 'https://example.com/stream.m3u8'
+    return render_template('index.html', video_url=video_url)
+
+
+@app.route('/clip', methods=['POST'])
+def clip():
+    data = request.get_json(force=True)
+    try:
+        args = SimpleNamespace(
+            endpoint_id=data['endpoint_id'],
+            start=data['start'],
+            end=data['end'],
+            bucket=data['bucket'],
+            manifest_prefix=data['manifest_prefix'],
+            role_arn=data['role_arn'],
+            region=data.get('region', 'us-east-1')
+        )
+        job = create_clip(args)
+        return jsonify({'status': 'ok', 'job_id': job['Id']})
+    except Exception as exc:
+        return jsonify({'status': 'error', 'message': str(exc)}), 400
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- change command-line and web interface to accept start and end times instead of duration
- update README usage and description for new parameters
- add buttons in HTML to set start and end to the current time

## Testing
- `python -m py_compile live_clipping.py web_app.py`
- `python web_app.py` *(fails: `ModuleNotFoundError: No module named 'flask'`)*