### PR TITLE
Add interactive frame-level clip selection

### DIFF
--- a/live_clipping.py
+++ b/live_clipping.py
@@ -16,6 +16,7 @@ def parse_args():
                         help='S3 bucket for the harvested clip')
     parser.add_argument('--manifest-prefix', required=True,
                         help='Prefix for the clipped manifest key')
+    parser.add_argument('--title', help='Optional clip title')
     parser.add_argument('--role-arn', required=True,
                         help='IAM Role ARN that MediaPackage uses to write to S3')
     parser.add_argument('--region', default='us-east-1', help='AWS region')
@@ -26,8 +27,13 @@ def create_clip(args):
     start_time = datetime.fromisoformat(args.start)
     end_time = datetime.fromisoformat(args.end)
     client = boto3.client('mediapackage', region_name=args.region)
+    if getattr(args, 'title', None):
+        safe_title = args.title.replace(' ', '-')
+        clip_id = f"{safe_title}-{int(datetime.utcnow().timestamp())}"
+    else:
+        clip_id = f"clip-{int(datetime.utcnow().timestamp())}"
     response = client.create_harvest_job(
-        Id=f"clip-{int(datetime.utcnow().timestamp())}",
+        Id=clip_id,
         StartTime=start_time.isoformat()+"Z",
         EndTime=end_time.isoformat()+"Z",
         OriginEndpointId=args.endpoint_id,

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,23 +7,39 @@
         body { font-family: Arial, sans-serif; margin: 20px; }
         video { display: block; margin-bottom: 20px; }
         label { display: block; margin: 5px 0; }
+        #container { position: relative; display: inline-block; }
+        #hover_display {
+            position: absolute;
+            top: 5px;
+            left: 5px;
+            background: rgba(0, 0, 0, 0.7);
+            color: #fff;
+            padding: 2px 4px;
+            font-size: 12px;
+            display: none;
+        }
     </style>
 </head>
 <body>
 <h1>AWS MediaLive Clipping</h1>
 
-<video id="video" width="640" controls autoplay>
-    <source src="{{ video_url }}" type="application/vnd.apple.mpegurl">
-    Your browser does not support the video tag.
-</video>
+<div id="container">
+    <video id="video" width="640" controls autoplay>
+        <source src="{{ video_url }}" type="application/vnd.apple.mpegurl">
+        Your browser does not support the video tag.
+    </video>
+    <div id="hover_display"></div>
+</div>
 
 <div>
     <label>Start Time (UTC): <input type="text" id="start"></label>
     <button onclick="setStartNow()">Set Start to Now</button>
+    <button onclick="setStartFrame()">Set Start Here</button>
 </div>
 <div>
     <label>End Time (UTC): <input type="text" id="end"></label>
     <button onclick="setEndNow()">Set End to Now</button>
+    <button onclick="setEndFrame()">Set End Here</button>
 </div>
 <div>
     <label>Endpoint ID: <input type="text" id="endpoint_id"></label>
@@ -35,6 +51,9 @@
     <label>Manifest Prefix: <input type="text" id="manifest_prefix"></label>
 </div>
 <div>
+    <label>Clip Title: <input type="text" id="title"></label>
+</div>
+<div>
     <label>Role ARN: <input type="text" id="role_arn"></label>
 </div>
 <div>
@@ -42,6 +61,7 @@
 </div>
 
 <button onclick="createClip()">Create Clip</button>
+<button onclick="previewClip()">Preview Clip</button>
 
 <pre id="result"></pre>
 
@@ -56,6 +76,61 @@ function setEndNow() {
     document.getElementById('end').value = now;
 }
 
+const video = document.getElementById('video');
+const hoverDisplay = document.getElementById('hover_display');
+let hoverSeconds = 0;
+let startSeconds = 0;
+let endSeconds = 0;
+
+function formatTime(sec) {
+    const s = Math.floor(sec);
+    const h = Math.floor(s / 3600).toString().padStart(2, '0');
+    const m = Math.floor((s % 3600) / 60).toString().padStart(2, '0');
+    const secs = (s % 60).toString().padStart(2, '0');
+    return `${h}:${m}:${secs}`;
+}
+
+video.addEventListener('mousemove', e => {
+    const rect = video.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const percent = x / rect.width;
+    hoverSeconds = percent * video.duration;
+    hoverDisplay.textContent = formatTime(hoverSeconds);
+    hoverDisplay.style.display = 'block';
+});
+
+video.addEventListener('mouseleave', () => {
+    hoverDisplay.style.display = 'none';
+});
+
+function isoFromCurrent(seconds) {
+    const now = new Date();
+    const diff = video.currentTime - seconds;
+    return new Date(now.getTime() - diff * 1000).toISOString().slice(0, 19);
+}
+
+function setStartFrame() {
+    startSeconds = hoverSeconds;
+    document.getElementById('start').value = isoFromCurrent(hoverSeconds);
+}
+
+function setEndFrame() {
+    endSeconds = hoverSeconds;
+    document.getElementById('end').value = isoFromCurrent(hoverSeconds);
+}
+
+function previewClip() {
+    video.currentTime = startSeconds;
+    video.play();
+    const handler = () => {
+        if (video.currentTime >= endSeconds) {
+            video.pause();
+            video.removeEventListener('timeupdate', handler);
+        }
+    };
+    video.addEventListener('timeupdate', handler);
+}
+
 async function createClip() {
     const payload = {
         endpoint_id: document.getElementById('endpoint_id').value,
@@ -63,6 +138,7 @@ async function createClip() {
         end: document.getElementById('end').value,
         bucket: document.getElementById('bucket').value,
         manifest_prefix: document.getElementById('manifest_prefix').value,
+        title: document.getElementById('title').value,
         role_arn: document.getElementById('role_arn').value,
         region: document.getElementById('region').value
     };

--- a/web_app.py
+++ b/web_app.py
@@ -22,6 +22,7 @@ def clip():
             end=data['end'],
             bucket=data['bucket'],
             manifest_prefix=data['manifest_prefix'],
+            title=data.get('title'),
             role_arn=data['role_arn'],
             region=data.get('region', 'us-east-1')
         )


### PR DESCRIPTION
## Summary
- allow specifying optional clip title for jobs
- expose clip title in Flask API
- enhance web interface to pick start/end frames from video with hover preview, preview clip, and show hovered time

## Testing
- `python -m py_compile live_clipping.py web_app.py`