### PR TITLE
Add local HLS playback instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,23 @@ Then open `http://localhost:5000` in your browser. The page shows a video player
 and a form to submit the start and end times along with other parameters. After
 filling out the fields press "Create Clip" and the server will request a harvest
 job from MediaPackage.
+
+### Playing a local HLS stream
+
+To test the interface with a locally hosted HLS manifest, start an HTTP server
+in the directory containing your `.m3u8` and segment files:
+
+```bash
+cd /path/to/hls/files
+python -m http.server 8000
+```
+
+Then launch the Flask app while specifying the local manifest URL via the
+`VIDEO_URL` environment variable:
+
+```bash
+VIDEO_URL=http://localhost:8000/stream.m3u8 python web_app.py
+```
+
+Open `http://localhost:5000` and the player will load the stream from your
+local server.

--- a/web_app.py
+++ b/web_app.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from flask import Flask, render_template, request, jsonify
+import os
 from live_clipping import create_clip
 
 app = Flask(__name__)
@@ -7,8 +8,8 @@ app = Flask(__name__)
 
 @app.route('/')
 def index():
-    # Replace with your HLS manifest URL
-    video_url = 'https://example.com/stream.m3u8'
+    # Use VIDEO_URL env var or fallback to placeholder URL
+    video_url = os.environ.get('VIDEO_URL', 'https://example.com/stream.m3u8')
     return render_template('index.html', video_url=video_url)
 
 


### PR DESCRIPTION
## Summary
- allow video URL to be set via VIDEO_URL environment variable
- document how to play a local HLS stream using the new variable

## Testing
- `python -m py_compile web_app.py live_clipping.py`