### PR TITLE
Add millisecond clip precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ Then open `http://localhost:5000` in your browser. The page shows a video player
 and a form to submit the start and end times along with other parameters. After
 filling out the fields press "Create Clip" and the server will request a harvest
 job from MediaPackage.
+
+The web page shows the current playback time when you hover over the video.
+Click **Set Start Here** and **Set End Here** to mark the boundaries with
+frame‑level precision and optionally provide a title for the clip. The
+**Preview Clip** button plays back just the selected range so you can verify the
+cut before creating it.

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,8 @@ createApp({
             const h = String(Math.floor(s / 3600)).padStart(2, '0');
             const m = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
             const secs = String(s % 60).padStart(2, '0');
-            return `${h}:${m}:${secs}`;
+            const ms = String(Math.floor((sec - s) * 1000)).padStart(3, '0');
+            return `${h}:${m}:${secs}.${ms}`;
         };
 
         const onVideoMove = e => {
@@ -110,15 +111,15 @@ createApp({
         const isoFromCurrent = seconds => {
             const now = new Date();
             const diff = video.value.currentTime - seconds;
-            return new Date(now.getTime() - diff * 1000).toISOString().slice(0, 19);
+            return new Date(now.getTime() - diff * 1000).toISOString().slice(0, 23);
         };
 
         const setStartNow = () => {
-            start.value = new Date().toISOString().slice(0, 19);
+            start.value = new Date().toISOString().slice(0, 23);
         };
 
         const setEndNow = () => {
-            end.value = new Date().toISOString().slice(0, 19);
+            end.value = new Date().toISOString().slice(0, 23);
         };
 
         const setStartFrame = () => {


### PR DESCRIPTION
## Summary
- display milliseconds when hovering over the video
- store start and end times with millisecond precision
- document how to interactively choose clip boundaries and preview the clip

## Testing
- `python -m py_compile live_clipping.py web_app.py`